### PR TITLE
Exercise branch-deploy TypeScript candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+branch-deploy TypeScript acceptance


### PR DESCRIPTION
Adds a harmless marker used to verify exact pull-request-head checkout while exercising the pinned branch-deploy TypeScript candidate. The marker will be removed in the restore PR after the acceptance matrix completes.