### PR TITLE
Pin branch-deploy hardening candidate

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grantbirki/branch-deploy@main
+      - uses: grantbirki/branch-deploy@a135df25401c9513be3882f886f74e1d4d0729be
         id: branch-deploy
         with:
           sticky_locks: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
+        uses: grantbirki/branch-deploy@a135df25401c9513be3882f886f74e1d4d0729be # replace with the latest version of this Action
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@main
+        uses: grantbirki/branch-deploy@a135df25401c9513be3882f886f74e1d4d0729be
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
Temporarily pins the IssueOps, merge-deploy, and unlock-on-merge workflows to branch-deploy candidate `a135df25401c9513be3882f886f74e1d4d0729be` for exact-SHA acceptance.

The references will be restored to `@main` after the acceptance matrix completes.