### PR TITLE
Validate branch-deploy hardening candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+branch-deploy TypeScript-native acceptance


### PR DESCRIPTION
Adds a harmless marker used to validate the pinned branch-deploy candidate across IssueOps, deployment, lock, merge, and automatic unlock paths.

The marker will be removed during workflow restoration.