### PR TITLE
Exercise branch-deploy leaf candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+branch-deploy leaf-dependency acceptance


### PR DESCRIPTION
Add a harmless marker used to exercise the exact branch-deploy dependency-reduction candidate through the established IssueOps acceptance matrix.