### PR TITLE
Restore branch-deploy workflow references

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grantbirki/branch-deploy@8843d3fa18ed95e6f310d45bbaa058f718290628
+      - uses: grantbirki/branch-deploy@main
         id: branch-deploy
         with:
           sticky_locks: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@8843d3fa18ed95e6f310d45bbaa058f718290628 # replace with the latest version of this Action
+        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@8843d3fa18ed95e6f310d45bbaa058f718290628
+        uses: grantbirki/branch-deploy@main
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow

--- a/noop
+++ b/noop
@@ -6,5 +6,3 @@ test
 test3
 
 asdf
-
-branch-deploy leaf-dependency acceptance


### PR DESCRIPTION
Return the three acceptance workflows to `grantbirki/branch-deploy@main` and remove the temporary acceptance marker.