### PR TITLE
Exercise branch-deploy core candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+branch-deploy core adapter acceptance


### PR DESCRIPTION
Add a harmless marker for end-to-end acceptance of the pinned branch-deploy candidate.