### PR TITLE
Exercise branch-deploy native Node candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+native Node tooling acceptance


### PR DESCRIPTION
Add a harmless marker for end-to-end acceptance of the pinned branch-deploy candidate.