### PR TITLE
Restore branch-deploy workflow references

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grantbirki/branch-deploy@8f00163a18aa2f1cc59078bc19a49578106c5e5c
+      - uses: grantbirki/branch-deploy@main
         id: branch-deploy
         with:
           sticky_locks: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@8f00163a18aa2f1cc59078bc19a49578106c5e5c # replace with the latest version of this Action
+        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@8f00163a18aa2f1cc59078bc19a49578106c5e5c
+        uses: grantbirki/branch-deploy@main
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow

--- a/noop
+++ b/noop
@@ -6,5 +6,3 @@ test
 test3
 
 asdf
-
-precheck pagination acceptance


### PR DESCRIPTION
Restore all temporary branch-deploy pins to main and remove the acceptance marker.