### PR TITLE
Exercise atomic lock acceptance

### DIFF
--- a/acceptance-marker.txt
+++ b/acceptance-marker.txt
@@ -1,0 +1,1 @@
+Temporary branch-deploy acceptance marker.


### PR DESCRIPTION
Adds a temporary harmless marker used to exercise the exact branch-deploy candidate across IssueOps, merge-deploy, and unlock-on-merge paths.