### PR TITLE
Restore branch deploy sandbox configuration

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grantbirki/branch-deploy@1cd3d1a77c2790e151d1149d3ccd101b5bbbe76c
+      - uses: grantbirki/branch-deploy@main
         id: branch-deploy
         with:
           sticky_locks: true
@@ -34,35 +34,6 @@ jobs:
           #allow_sha_deployments: true
           #checks: 'required'
           #ignored_checks: 'test1,test3'
-
-      - name: assert structured result
-        if: ${{ always() }}
-        env:
-          ACTION_OUTCOME: ${{ steps.branch-deploy.outcome }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          DECISION: ${{ steps.branch-deploy.outputs.decision }}
-          REASON_CODE: ${{ steps.branch-deploy.outputs.reason_code }}
-          RESULT: ${{ steps.branch-deploy.outputs.result }}
-        run: |
-          node <<'NODE'
-          const assert = require('node:assert/strict')
-          assert.equal(process.env.ACTION_OUTCOME, 'success')
-          const result = JSON.parse(process.env.RESULT)
-          assert.equal(result.schema_version, 1)
-          assert.equal(result.decision, process.env.DECISION)
-          assert.equal(result.reason_code, process.env.REASON_CODE)
-          const command = process.env.COMMENT_BODY.trim().split(/\s+/u)[0]
-          const expected = {
-            '.deploy': ['deploy', 'deployment_ready'],
-            '.help': ['help', 'help_completed'],
-            '.noop': ['noop', 'noop_ready'],
-            '.unlock': ['unlock', 'unlock_completed'],
-            '.wcid': ['lock_info', 'lock_info_completed']
-          }[command]
-          if (expected) {
-            assert.deepEqual([result.operation, result.reason_code], expected)
-          }
-          NODE
 
       # Checkout your projects repository based on the ref provided by the branch-deploy step
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,34 +12,11 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@1cd3d1a77c2790e151d1149d3ccd101b5bbbe76c # replace with the latest version of this Action
+        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy
           # environment: production # optional, defaults to 'production'
-
-      - name: assert structured result
-        if: ${{ always() }}
-        env:
-          ACTION_OUTCOME: ${{ steps.deployment-check.outcome }}
-          DECISION: ${{ steps.deployment-check.outputs.decision }}
-          REASON_CODE: ${{ steps.deployment-check.outputs.reason_code }}
-          RESULT: ${{ steps.deployment-check.outputs.result }}
-        run: |
-          node <<'NODE'
-          const assert = require('node:assert/strict')
-          assert.equal(process.env.ACTION_OUTCOME, 'success')
-          const result = JSON.parse(process.env.RESULT)
-          assert.equal(result.schema_version, 1)
-          assert.equal(result.operation, 'merge_deploy')
-          assert.equal(result.decision, process.env.DECISION)
-          assert.equal(result.reason_code, process.env.REASON_CODE)
-          const expected = {
-            merge_deploy_required: 'continue',
-            merge_deploy_not_required: 'stop'
-          }[result.reason_code]
-          assert.equal(result.decision, expected)
-          NODE
 
       # Now we can conditionally 'gate' our deployment logic based on the output of the Action
       # If the Action returns 'true' for the 'continue' output, we can continue with our deployment logic

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,28 +14,8 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@1cd3d1a77c2790e151d1149d3ccd101b5bbbe76c
+        uses: grantbirki/branch-deploy@main
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
           environment_targets: production,development,staging,super production,mellow staging
-
-      - name: assert structured result
-        if: ${{ always() }}
-        env:
-          ACTION_OUTCOME: ${{ steps.unlock-on-merge.outcome }}
-          DECISION: ${{ steps.unlock-on-merge.outputs.decision }}
-          REASON_CODE: ${{ steps.unlock-on-merge.outputs.reason_code }}
-          RESULT: ${{ steps.unlock-on-merge.outputs.result }}
-        run: |
-          node <<'NODE'
-          const assert = require('node:assert/strict')
-          assert.equal(process.env.ACTION_OUTCOME, 'success')
-          const result = JSON.parse(process.env.RESULT)
-          assert.equal(result.schema_version, 1)
-          assert.equal(result.operation, 'unlock_on_merge')
-          assert.equal(result.decision, 'complete')
-          assert.equal(result.reason_code, 'unlock_on_merge_completed')
-          assert.equal(result.decision, process.env.DECISION)
-          assert.equal(result.reason_code, process.env.REASON_CODE)
-          NODE

--- a/noop
+++ b/noop
@@ -6,5 +6,3 @@ test
 test3
 
 asdf
-
-structured result acceptance


### PR DESCRIPTION
Restore all branch-deploy workflow references to `main`, remove the temporary result assertions, and remove the acceptance marker. The resulting functional tree matches the pre-test baseline.
