### PR TITLE
Exercise v12 hardening candidate

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+v12 hardening acceptance marker


### PR DESCRIPTION
Add a harmless marker for exact-SHA v12 hardening acceptance. The marker will be removed when the sandbox workflows are restored.