### PR TITLE
Add v12 raw results acceptance fixture

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: grantbirki/branch-deploy@c89e0aa0c620af41144388bf04c395ae245a2532
         id: branch-deploy
+        env:
+          DEPLOY_MESSAGE: 'Live acceptance output with inert delimiters: {{ actor }}'
         with:
           sticky_locks: true
           trigger: ".deploy"


### PR DESCRIPTION
Provide a temporary DEPLOY_MESSAGE value containing template delimiters so the exact-SHA live run proves raw results are substituted once and remain inert. This fixture will be removed with the other acceptance-only configuration.