### PR TITLE
V12: pin release acceptance candidate

### DIFF
--- a/.github/deployment_message.md
+++ b/.github/deployment_message.md
@@ -1,0 +1,9 @@
+# Trusted v12 acceptance result
+
+Environment: `{{ environment }}`
+
+{% if noop %}Noop completed.{% else %}Deployment completed.{% endif %}
+
+{{ results }}
+
+Trusted template marker: `v12-release-candidate`

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grantbirki/branch-deploy@main
+      - uses: GrantBirki/branch-deploy@8be7b00892ea7d7c1532c18da97c1dc99ecc3bf7
         id: branch-deploy
+        env:
+          DEPLOY_MESSAGE: 'Live result with inert delimiters: {{ actor }}'
         with:
           sticky_locks: true
           trigger: ".deploy"
@@ -27,13 +29,61 @@ jobs:
           commit_verification: true
           stable_branch: 'main'
           environment: "production"
+          environment_urls: "production|https://production.example.test,stage|https://stage.example.test,dev|disabled"
           admins: "GrantBirki"
+          deploy_message_path: .github/deployment_message.md
           #deployment_confirmation: true
           #deployment_confirmation_timeout: 20
           #checks: 'quality_gate'
           #allow_sha_deployments: true
           #checks: 'required'
           #ignored_checks: 'test1,test3'
+
+      - name: acceptance evidence
+        if: ${{ always() }}
+        env:
+          ACTION_OUTCOME: ${{ steps.branch-deploy.outcome }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          CONTINUE: ${{ steps.branch-deploy.outputs.continue }}
+          DECISION: ${{ steps.branch-deploy.outputs.decision }}
+          ENVIRONMENT: ${{ steps.branch-deploy.outputs.environment }}
+          ENVIRONMENT_URL: ${{ steps.branch-deploy.outputs.environment_url }}
+          NOOP: ${{ steps.branch-deploy.outputs.noop }}
+          PARAMS: ${{ steps.branch-deploy.outputs.params }}
+          PARSED_PARAMS: ${{ steps.branch-deploy.outputs.parsed_params }}
+          REASON_CODE: ${{ steps.branch-deploy.outputs.reason_code }}
+          REF: ${{ steps.branch-deploy.outputs.ref }}
+          RESULT: ${{ steps.branch-deploy.outputs.result }}
+          SHA: ${{ steps.branch-deploy.outputs.sha }}
+          TYPE: ${{ steps.branch-deploy.outputs.type }}
+        run: |
+          node <<'NODE'
+          const assert = require('node:assert/strict')
+          assert.ok(['success', 'failure'].includes(process.env.ACTION_OUTCOME))
+          assert.ok(process.env.RESULT)
+          const result = JSON.parse(process.env.RESULT)
+          assert.equal(result.schema_version, 1)
+          assert.equal(result.decision, process.env.DECISION)
+          assert.equal(result.reason_code, process.env.REASON_CODE)
+          if (process.env.PARSED_PARAMS) JSON.parse(process.env.PARSED_PARAMS)
+          const evidence = {
+            action_outcome: process.env.ACTION_OUTCOME,
+            command: process.env.COMMENT_BODY,
+            continue: process.env.CONTINUE,
+            decision: process.env.DECISION,
+            environment: process.env.ENVIRONMENT,
+            environment_url: process.env.ENVIRONMENT_URL,
+            noop: process.env.NOOP,
+            params: process.env.PARAMS,
+            parsed_params: process.env.PARSED_PARAMS,
+            reason_code: process.env.REASON_CODE,
+            ref: process.env.REF,
+            result,
+            sha: process.env.SHA,
+            type: process.env.TYPE
+          }
+          console.log(`ACCEPTANCE_EVIDENCE_B64=${Buffer.from(JSON.stringify(evidence)).toString('base64')}`)
+          NODE
 
       # Checkout your projects repository based on the ref provided by the branch-deploy step
       - uses: actions/checkout@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main # <-- This is the default branch for your repository
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -12,11 +13,37 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
+        uses: GrantBirki/branch-deploy@8be7b00892ea7d7c1532c18da97c1dc99ecc3bf7 # exact v12 release candidate
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy
           # environment: production # optional, defaults to 'production'
+
+      - name: acceptance evidence
+        if: ${{ always() }}
+        env:
+          ACTION_OUTCOME: ${{ steps.deployment-check.outcome }}
+          DECISION: ${{ steps.deployment-check.outputs.decision }}
+          REASON_CODE: ${{ steps.deployment-check.outputs.reason_code }}
+          RESULT: ${{ steps.deployment-check.outputs.result }}
+        run: |
+          node <<'NODE'
+          const assert = require('node:assert/strict')
+          assert.equal(process.env.ACTION_OUTCOME, 'success')
+          const result = JSON.parse(process.env.RESULT)
+          assert.equal(result.schema_version, 1)
+          assert.equal(result.operation, 'merge_deploy')
+          assert.equal(result.decision, process.env.DECISION)
+          assert.equal(result.reason_code, process.env.REASON_CODE)
+          assert.equal(result.decision, {
+            merge_deploy_required: 'continue',
+            merge_deploy_not_required: 'stop'
+          }[result.reason_code])
+          console.log(`ACCEPTANCE_EVIDENCE_B64=${Buffer.from(JSON.stringify({
+            action_outcome: process.env.ACTION_OUTCOME,
+            result
+          })).toString('base64')}`)
+          NODE
 
       # Now we can conditionally 'gate' our deployment logic based on the output of the Action
       # If the Action returns 'true' for the 'continue' output, we can continue with our deployment logic

--- a/.github/workflows/title-check.yml
+++ b/.github/workflows/title-check.yml
@@ -1,0 +1,18 @@
+name: title-check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  title-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: title-check
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          node -e "require('node:assert/strict').match(process.env.TITLE, /^V12: /u)"

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,8 +14,32 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@main
+        uses: GrantBirki/branch-deploy@8be7b00892ea7d7c1532c18da97c1dc99ecc3bf7
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
           environment_targets: production,development,staging,super production,mellow staging
+
+      - name: acceptance evidence
+        if: ${{ always() }}
+        env:
+          ACTION_OUTCOME: ${{ steps.unlock-on-merge.outcome }}
+          DECISION: ${{ steps.unlock-on-merge.outputs.decision }}
+          REASON_CODE: ${{ steps.unlock-on-merge.outputs.reason_code }}
+          RESULT: ${{ steps.unlock-on-merge.outputs.result }}
+        run: |
+          node <<'NODE'
+          const assert = require('node:assert/strict')
+          assert.equal(process.env.ACTION_OUTCOME, 'success')
+          const result = JSON.parse(process.env.RESULT)
+          assert.equal(result.schema_version, 1)
+          assert.equal(result.operation, 'unlock_on_merge')
+          assert.equal(result.decision, 'complete')
+          assert.equal(result.reason_code, 'unlock_on_merge_completed')
+          assert.equal(result.decision, process.env.DECISION)
+          assert.equal(result.reason_code, process.env.REASON_CODE)
+          console.log(`ACCEPTANCE_EVIDENCE_B64=${Buffer.from(JSON.stringify({
+            action_outcome: process.env.ACTION_OUTCOME,
+            result
+          })).toString('base64')}`)
+          NODE


### PR DESCRIPTION
Pin all Branch Deploy workflows to the exact v12 candidate SHA and add temporary live assertions, a trusted template, environment URLs, same-SHA CI rerun coverage, and dispatchable merge-deploy coverage. This public sandbox configuration will be restored exactly after the extended acceptance matrix completes.