### PR TITLE
V12: extended standard acceptance

### DIFF
--- a/noop
+++ b/noop
@@ -6,3 +6,5 @@ test
 test3
 
 asdf
+
+v12 release standard acceptance marker


### PR DESCRIPTION
Harmless marker for the standard exact-SHA v12 live acceptance matrix. This intentionally starts with an invalid title to exercise same-SHA CI rerun handling and will be restored after acceptance.