### PR TITLE
V12: enable confirmation acceptance

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -32,8 +32,8 @@ jobs:
           environment_urls: "production|https://production.example.test,stage|https://stage.example.test,dev|disabled"
           admins: "GrantBirki"
           deploy_message_path: .github/deployment_message.md
-          #deployment_confirmation: true
-          #deployment_confirmation_timeout: 20
+          deployment_confirmation: true
+          deployment_confirmation_timeout: 20
           #checks: 'quality_gate'
           #allow_sha_deployments: true
           #checks: 'required'


### PR DESCRIPTION
Temporarily enable the existing deployment confirmation inputs for live v12 acceptance testing.