### PR TITLE
V12: repin final acceptance candidate

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GrantBirki/branch-deploy@b4e15e5a1244a8b85d99dd63c4a6e605e5bd4851
+      - uses: GrantBirki/branch-deploy@dbb51ebdfd7a934f0e47ef5fa97ea94f87630e4d
         id: branch-deploy
         env:
           DEPLOY_MESSAGE: 'Live result with inert delimiters: {{ actor }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: GrantBirki/branch-deploy@b4e15e5a1244a8b85d99dd63c4a6e605e5bd4851 # exact v12 release candidate
+        uses: GrantBirki/branch-deploy@dbb51ebdfd7a934f0e47ef5fa97ea94f87630e4d # exact v12 release candidate
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: GrantBirki/branch-deploy@b4e15e5a1244a8b85d99dd63c4a6e605e5bd4851
+        uses: GrantBirki/branch-deploy@dbb51ebdfd7a934f0e47ef5fa97ea94f87630e4d
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
Pin the temporary live-acceptance workflows to the final corrected v12 candidate after the GraphQL deployment-history fix.