### PR TITLE
Test PR stack deployments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.issue-495/** @GrantBirki

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Call the branch-deploy Action - name it something else if you want (I did here for clarity)
       - name: deployment check
-        uses: grantbirki/branch-deploy@main # replace with the latest version of this Action
+        uses: GrantBirki/branch-deploy@117b39b39e0984d3a0fbaabe9454807f0ce5b9ae # replace with the latest version of this Action
         id: deployment-check # ensure you have an 'id' set so you can reference the output of the Action later on
         with:
           merge_deploy_mode: "true" # required, tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/issue-495-acceptance.yml
+++ b/.github/workflows/issue-495-acceptance.yml
@@ -1,0 +1,342 @@
+name: issue-495-acceptance
+run-name: ${{ github.event_name == 'issue_comment' && format('issue-495 PR {0} comment {1}', github.event.issue.number, github.event.comment.id) || 'issue-495 fixture setup' }}
+
+on:
+  workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+concurrency:
+  group: issue-495-acceptance
+  cancel-in-progress: false
+
+env:
+  CANDIDATE_SHA: 117b39b39e0984d3a0fbaabe9454807f0ce5b9ae
+
+jobs:
+  setup:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository == 'GrantBirki/actions-sandbox' && github.actor == 'GrantBirki' && github.triggering_actor == 'GrantBirki' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Open the three bot-authored fixture PRs
+        shell: bash
+        run: |
+          set -euo pipefail
+          base=main
+          for layer in a b c; do
+            head="issue-495-stack-$layer"
+            gh api "repos/$GITHUB_REPOSITORY/commits/$head" --jq '.commit.verification.verified' | jq -e '. == true' >/dev/null
+            gh api "repos/$GITHUB_REPOSITORY/compare/$base...$head" --jq '{status, behind_by}' | jq -e '.status == "ahead" and .behind_by == 0' >/dev/null
+            base="$head"
+          done
+
+          pulls=()
+          base=main
+          for layer in a b c; do
+            head="issue-495-stack-$layer"
+            existing=$(gh api --method GET "repos/$GITHUB_REPOSITORY/pulls" -f state=open -f head="GrantBirki:$head" -f base="$base")
+            if [[ $(jq length <<<"$existing") == 0 ]]; then
+              number=$(gh api --method POST "repos/$GITHUB_REPOSITORY/pulls" -f head="$head" -f base="$base" -f title="Issue 495 acceptance layer $layer" -f body='Disposable fixture for github/branch-deploy#495.' --jq '.number')
+            else
+              jq -e 'length == 1 and .[0].user.login == "github-actions[bot]"' <<<"$existing" >/dev/null
+              number=$(jq -r '.[0].number' <<<"$existing")
+            fi
+            pulls+=("$number")
+            base="$head"
+          done
+          numbers=$(printf '%s\n' "${pulls[@]}" | jq -s '.')
+          memberships=()
+          for number in "${pulls[@]}"; do
+            memberships+=("$(gh api graphql -f query='query($number:Int!){repository(owner:"GrantBirki",name:"actions-sandbox"){pullRequest(number:$number){stack{id number size baseRefName entries(first:100){pageInfo{hasNextPage}nodes{pullRequest{number}}}}}}}' -F number="$number" | jq -c '.data.repository.pullRequest.stack')")
+          done
+          current=$(printf '%s\n' "${memberships[@]}" | jq -s '.')
+          if jq -e 'all(.[]; . == null)' <<<"$current" >/dev/null; then
+            jq -n --argjson numbers "$numbers" '{pull_requests:$numbers}' | gh api --method POST "repos/$GITHUB_REPOSITORY/stacks" -H 'X-GitHub-Api-Version: 2026-03-10' --input - --jq '{number, base}'
+          else
+            jq -e --argjson numbers "$numbers" '.[0].id as $id | $id != null and all(.[]; .id == $id and .size == 3 and .baseRefName == "main" and .entries.pageInfo.hasNextPage == false and [.entries.nodes[].pullRequest.number] == $numbers)' <<<"$current" >/dev/null
+          fi
+          printf 'Candidate: `%s`\n\nFixture PRs: `%s`\n' "$CANDIDATE_SHA" "$(jq -c . <<<"$numbers")" >>"$GITHUB_STEP_SUMMARY"
+
+  acceptance:
+    if: ${{ github.event_name == 'issue_comment' && github.repository == 'GrantBirki/actions-sandbox' && github.actor == 'GrantBirki' && github.triggering_actor == 'GrantBirki' && github.event.comment.user.login == 'GrantBirki' && github.event.issue.pull_request && startsWith(github.event.comment.body, '.stack495') && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      checks: read
+      contents: write
+      deployments: write
+      pull-requests: write
+      statuses: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+    outputs:
+      prepared: ${{ steps.snapshot.outputs.prepared }}
+      target: ${{ steps.request.outputs.target }}
+      sticky: ${{ steps.request.outputs.sticky }}
+      expected: ${{ steps.request.outputs.expected }}
+      expected_ref: ${{ steps.snapshot.outputs.expected_ref }}
+      before_deployments: ${{ steps.snapshot.outputs.before_deployments }}
+      before_lock: ${{ steps.snapshot.outputs.before_lock }}
+      other_locks: ${{ steps.snapshot.outputs.other_locks }}
+      outcome: ${{ steps.branch-deploy.outcome }}
+      reason: ${{ steps.branch-deploy.outputs.reason_code }}
+      deployment_id: ${{ steps.branch-deploy.outputs.deployment_id }}
+      sha: ${{ steps.branch-deploy.outputs.sha }}
+    steps:
+      - name: Select a fixed acceptance mode
+        id: request
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          match = re.fullmatch(r'(\.stack495(?:-(?:disabled|policy-noop|policy|sticky|confirm|noop|unlock|help|wcid))?)(?:[ \t]+(main))?(?:[ \t]+(?:(to)[ \t]+)?(issue-495|production))?(?:[ \t]+\|[ \t]+--expect=(prechecks_failed|ref_changed|lock_conflict))?', os.environ['COMMENT_BODY'].strip())
+          if match is None:
+              raise SystemExit('Unsupported issue-495 command')
+          command, stable, preposition, target, override = match.groups()
+          operation = {'noop': 'noop', 'policy-noop': 'noop', 'unlock': 'unlock', 'help': 'help', 'wcid': 'lock_info'}.get(command.removeprefix('.stack495-'), 'deploy')
+          if stable and command != '.stack495':
+              raise SystemExit('Only .stack495 supports the main rollback argument')
+          if target and ((operation in ('deploy', 'noop')) != (preposition == 'to')):
+              raise SystemExit('Use to ENV for deployments and bare ENV for lock commands')
+          if operation == 'help' and target:
+              raise SystemExit('Help does not take an environment')
+          if override and operation not in ('deploy', 'noop'):
+              raise SystemExit('Expected failures are only supported for deploy and noop')
+          expected = {'deploy': 'deployment_ready', 'noop': 'noop_ready', 'unlock': 'unlock_completed', 'help': 'help_completed', 'lock_info': 'lock_info_completed'}[operation]
+          if command == '.stack495-disabled':
+              expected = 'prechecks_failed'
+          values = {
+              'trigger': command if operation == 'deploy' else '.stack495',
+              'noop_trigger': command if operation == 'noop' else '.stack495-noop',
+              'stacks': str(command != '.stack495-disabled').lower(),
+              'checks': 'test1,issue-495-policy' if command in ('.stack495-policy', '.stack495-policy-noop') else 'required',
+              'sticky': str(command == '.stack495-sticky').lower(),
+              'confirm': str(command == '.stack495-confirm').lower(),
+              'operation': operation,
+              'expected': override or expected,
+              'target': target or 'issue-495',
+              'stable': str(stable is not None).lower(),
+          }
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.writelines(f'{key}={value}\n' for key, value in values.items())
+          PY
+
+      - name: Capture public metadata and protect existing locks
+        id: snapshot
+        env:
+          TARGET: ${{ steps.request.outputs.target }}
+          STABLE: ${{ steps.request.outputs.stable }}
+          STACKS: ${{ steps.request.outputs.stacks }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '{number, author:.user.login, base:{ref:.base.ref,sha:.base.sha},head:{ref:.head.ref,sha:.head.sha,repository:.head.repo.full_name}}')
+          jq -e --arg repo "$GITHUB_REPOSITORY" '.head.repository == $repo and (.head.ref | startswith("issue-495-")) and (.head.sha | test("^[0-9a-f]{40}$"))' <<<"$pr" >/dev/null
+          expected_sha=$(jq -r '.head.sha' <<<"$pr")
+          expected_ref=$(jq -r '.head.ref' <<<"$pr")
+          if [[ "$STABLE" == true ]]; then
+            expected_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')
+            expected_ref=main
+          fi
+          stack=$(gh api graphql -f query='query($number:Int!){repository(owner:"GrantBirki",name:"actions-sandbox"){pullRequest(number:$number){number headRefOid stackEntry{position} stack{id number size baseRefName entries(first:100){totalCount pageInfo{hasNextPage}nodes{position pullRequest{number headRefOid}}}}}}}' -F number="$PR_NUMBER" --jq '.data.repository.pullRequest')
+          jq -e --arg head "$(jq -r '.head.sha' <<<"$pr")" '.headRefOid == $head and (.stack == null or .stack.entries.pageInfo.hasNextPage == false)' <<<"$stack" >/dev/null
+          deploy_ref="$expected_ref"
+          if [[ "$STACKS" == true && "$STABLE" != true && $(jq -r '.stack != null' <<<"$stack") == true ]]; then
+            deploy_ref="$expected_sha"
+          fi
+          printf '%s\n' "$stack" >"$RUNNER_TEMP/issue-495-stack.json"
+          : >"$RUNNER_TEMP/issue-495-policy.jsonl"
+          while read -r number; do
+            gh api graphql -f query='query($number:Int!){repository(owner:"GrantBirki",name:"actions-sandbox"){pullRequest(number:$number){number state isDraft baseRefName headRefName headRefOid reviewDecision mergeStateStatus commits(last:1){nodes{commit{oid statusCheckRollup{state contexts(first:100){pageInfo{hasNextPage}nodes{__typename ... on CheckRun{name status conclusion checkSuite{app{databaseId}} isRequired(pullRequestNumber:$number)} ... on StatusContext{context state isRequired(pullRequestNumber:$number)}}}}}}}}}}' -F number="$number" --jq '.data.repository.pullRequest' | jq -c . >>"$RUNNER_TEMP/issue-495-policy.jsonl"
+          done < <(jq -r '([.number] + [.stack.entries.nodes[]?.pullRequest.number]) | unique | .[]' <<<"$stack")
+          {
+            printf 'Candidate: `%s`\n\n```json\n' "$CANDIDATE_SHA"
+            jq -c . <<<"$pr"
+            jq -c . <<<"$stack"
+            cat "$RUNNER_TEMP/issue-495-policy.jsonl"
+            printf '```\n'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+          locks=$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/" | jq -c '[.[] | select(.ref | endswith("-branch-deploy-lock")) | {ref,sha:.object.sha}] | sort_by(.ref)')
+          target_ref="refs/heads/$TARGET-branch-deploy-lock"
+          jq -e 'all(.[]; .ref != "refs/heads/global-branch-deploy-lock")' <<<"$locks" >/dev/null
+          before_lock=$(jq -r --arg ref "$target_ref" '.[] | select(.ref == $ref) | .sha' <<<"$locks")
+          if [[ -n "$before_lock" ]]; then
+            gh api --method GET "repos/$GITHUB_REPOSITORY/contents/lock.json" -f ref="$TARGET-branch-deploy-lock" --jq '.content' | base64 --decode | jq -e --arg target "$TARGET" --arg ref "$(jq -r '.head.ref' <<<"$pr")" --arg link "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER#issuecomment-" '.global == false and .environment == $target and .created_by == "GrantBirki" and .branch == $ref and (.link | startswith($link)) and (.link | ltrimstr($link) | test("^[0-9]+$"))' >/dev/null
+          fi
+          before_deployments=$(gh api --method GET "repos/$GITHUB_REPOSITORY/deployments" -f environment="$TARGET" -f per_page=100 | jq -c '[.[].id]')
+          {
+            printf 'expected_sha=%s\nexpected_ref=%s\ndeploy_ref=%s\nbase_ref=%s\n' "$expected_sha" "$expected_ref" "$deploy_ref" "$(jq -r '.base.ref' <<<"$pr")"
+            printf 'before_deployments=%s\nbefore_lock=%s\nother_locks=%s\nprepared=true\n' "$before_deployments" "$before_lock" "$(jq -c --arg ref "$target_ref" 'map(select(.ref != $ref))' <<<"$locks")"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Run the pinned Branch Deploy candidate
+        id: branch-deploy
+        continue-on-error: true
+        uses: GrantBirki/branch-deploy@117b39b39e0984d3a0fbaabe9454807f0ce5b9ae
+        with:
+          trigger: ${{ steps.request.outputs.trigger }}
+          noop_trigger: ${{ steps.request.outputs.noop_trigger }}
+          lock_trigger: .stack495-lock
+          unlock_trigger: .stack495-unlock
+          help_trigger: .stack495-help
+          lock_info_alias: .stack495-wcid
+          enable_pr_stacks: ${{ steps.request.outputs.stacks }}
+          stable_branch: main
+          environment: issue-495
+          environment_targets: issue-495,production
+          production_environments: production
+          admins: 'false'
+          checks: ${{ steps.request.outputs.checks }}
+          commit_verification: true
+          allow_forks: false
+          sticky_locks: ${{ steps.request.outputs.sticky }}
+          deployment_confirmation: ${{ steps.request.outputs.confirm }}
+          deployment_confirmation_timeout: 120
+
+      - name: Assert the action result
+        id: receipt
+        if: ${{ always() && steps.snapshot.outputs.prepared == 'true' }}
+        env:
+          EXPECTED: ${{ steps.request.outputs.expected }}
+          OPERATION: ${{ steps.request.outputs.operation }}
+          TARGET: ${{ steps.request.outputs.target }}
+          STABLE: ${{ steps.request.outputs.stable }}
+          STACKS: ${{ steps.request.outputs.stacks }}
+          EXPECTED_SHA: ${{ steps.snapshot.outputs.expected_sha }}
+          EXPECTED_REF: ${{ steps.snapshot.outputs.expected_ref }}
+          DEPLOY_REF: ${{ steps.snapshot.outputs.deploy_ref }}
+          BASE_REF: ${{ steps.snapshot.outputs.base_ref }}
+          BEFORE_DEPLOYMENTS: ${{ steps.snapshot.outputs.before_deployments }}
+          OUTCOME: ${{ steps.branch-deploy.outcome }}
+          RESULT: ${{ steps.branch-deploy.outputs.result }}
+          DECISION: ${{ steps.branch-deploy.outputs.decision }}
+          REASON: ${{ steps.branch-deploy.outputs.reason_code }}
+          CONTINUE: ${{ steps.branch-deploy.outputs.continue }}
+          SHA: ${{ steps.branch-deploy.outputs.sha }}
+          REF: ${{ steps.branch-deploy.outputs.ref }}
+          ACTUAL_BASE_REF: ${{ steps.branch-deploy.outputs.base_ref }}
+          DEPLOYMENT_ID: ${{ steps.branch-deploy.outputs.deployment_id }}
+          VERIFIED: ${{ steps.branch-deploy.outputs.commit_verified }}
+          SHA_DEPLOYMENT: ${{ steps.branch-deploy.outputs.sha_deployment }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -nc --arg candidate "$CANDIDATE_SHA" --arg outcome "$OUTCOME" --arg expected "$EXPECTED" --argjson result "$RESULT" '{candidate:$candidate,step_outcome:$outcome,expected_reason:$expected,result:$result}' | tee -a "$GITHUB_STEP_SUMMARY"
+          jq -e --arg decision "$DECISION" --arg reason "$REASON" --arg operation "$OPERATION" '.schema_version == 1 and .decision == $decision and .reason_code == $reason and .operation == $operation' <<<"$RESULT" >/dev/null
+          [[ "$REASON" == "$EXPECTED" ]]
+          if [[ "$EXPECTED" == deployment_ready || "$EXPECTED" == noop_ready ]]; then
+            [[ "$OUTCOME" == success && "$DECISION" == continue && "$CONTINUE" == true ]]
+            [[ "$SHA" == "$EXPECTED_SHA" && "$REF" == "$EXPECTED_REF" && "$ACTUAL_BASE_REF" == "$BASE_REF" && "$VERIFIED" == true && -z "$SHA_DEPLOYMENT" ]]
+            jq -e --arg sha "$SHA" --arg ref "$REF" --arg target "$TARGET" '.sha == $sha and .ref == $ref and .environment == $target' <<<"$RESULT" >/dev/null
+            if [[ "$STABLE" == true ]]; then
+              [[ $(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha') == "$SHA" ]]
+            else
+              [[ $(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha') == "$SHA" ]]
+            fi
+            if [[ "$STABLE" != true ]]; then
+              prefix=$(jq -c 'if .stack == null then [.number] else .stackEntry.position as $position | [.stack.entries.nodes[] | select(.position <= $position) | .pullRequest.number] end' "$RUNNER_TEMP/issue-495-stack.json")
+              jq -se --argjson prefix "$prefix" --arg operation "$OPERATION" 'all(.[] | select(.number as $number | $prefix | index($number)) | select(.state == "OPEN"); ($operation == "noop" or .reviewDecision == "APPROVED") and .commits.nodes[0].commit.oid == .headRefOid and .commits.nodes[0].commit.statusCheckRollup.contexts.pageInfo.hasNextPage == false and any(.commits.nodes[0].commit.statusCheckRollup.contexts.nodes[]; .__typename == "CheckRun" and .name == "test1" and .isRequired == true and .checkSuite.app.databaseId == 15368 and .conclusion == "SUCCESS"))' "$RUNNER_TEMP/issue-495-policy.jsonl" >/dev/null
+            fi
+            if [[ "$EXPECTED" == deployment_ready ]]; then
+              [[ "$DEPLOYMENT_ID" =~ ^[0-9]+$ ]]
+              jq -e --argjson id "$DEPLOYMENT_ID" '.deployment_type == "branch" and .deployment_id == $id' <<<"$RESULT" >/dev/null
+              gh api "repos/$GITHUB_REPOSITORY/deployments/$DEPLOYMENT_ID" | jq -e --arg sha "$SHA" --arg ref "$DEPLOY_REF" --arg target "$TARGET" '.sha == $sha and .ref == $ref and .environment == $target and .payload.type == "branch-deploy" and .payload.sha == $sha' >/dev/null
+            else
+              [[ -z "$DEPLOYMENT_ID" ]]
+              jq -e '.deployment_type == "noop" and .deployment_id == null' <<<"$RESULT" >/dev/null
+            fi
+          else
+            [[ "$CONTINUE" != true && -z "$DEPLOYMENT_ID" ]]
+            jq -e '.deployment_id == null' <<<"$RESULT" >/dev/null
+            case "$EXPECTED" in
+              prechecks_failed|ref_changed) [[ "$OUTCOME" == failure && "$DECISION" == failure ]] ;;
+              lock_conflict) [[ "$OUTCOME" == failure && "$DECISION" == stop ]] ;;
+              *) [[ "$OUTCOME" == success && "$DECISION" == complete ]] ;;
+            esac
+          fi
+          if [[ "$EXPECTED" != deployment_ready ]]; then
+            gh api --method GET "repos/$GITHUB_REPOSITORY/deployments" -f environment="$TARGET" -f per_page=100 | jq -e --argjson before "$BEFORE_DEPLOYMENTS" 'all(.[]; .id as $id | $before | index($id))' >/dev/null
+          fi
+
+      - name: Check out only the checked commit
+        if: ${{ steps.receipt.outcome == 'success' && steps.branch-deploy.outputs.continue == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ steps.branch-deploy.outputs.sha }}
+          path: checked-commit
+          persist-credentials: false
+
+      - name: Assert checkout identity without running PR code
+        if: ${{ steps.receipt.outcome == 'success' && steps.branch-deploy.outputs.continue == 'true' }}
+        env:
+          EXPECTED_SHA: ${{ steps.snapshot.outputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          actual=$(git -C checked-commit rev-parse HEAD)
+          [[ "$actual" == "$EXPECTED_SHA" ]]
+          printf '\nChecked out: `%s`\n' "$actual" >>"$GITHUB_STEP_SUMMARY"
+
+  verify-post:
+    needs: acceptance
+    if: ${{ always() && needs.acceptance.outputs.prepared == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      deployments: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.issue.number }}
+      TARGET: ${{ needs.acceptance.outputs.target }}
+      STICKY: ${{ needs.acceptance.outputs.sticky }}
+      EXPECTED_REF: ${{ needs.acceptance.outputs.expected_ref }}
+      BEFORE_DEPLOYMENTS: ${{ needs.acceptance.outputs.before_deployments }}
+      BEFORE_LOCK: ${{ needs.acceptance.outputs.before_lock }}
+      OTHER_LOCKS: ${{ needs.acceptance.outputs.other_locks }}
+      REASON: ${{ needs.acceptance.outputs.reason }}
+      DEPLOYMENT_ID: ${{ needs.acceptance.outputs.deployment_id }}
+      SHA: ${{ needs.acceptance.outputs.sha }}
+      ACCEPTANCE_RESULT: ${{ needs.acceptance.result }}
+    steps:
+      - name: Verify post completion and unrelated locks
+        shell: bash
+        run: |
+          set -euo pipefail
+          locks=$(gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/" | jq -c '[.[] | select(.ref | endswith("-branch-deploy-lock")) | {ref,sha:.object.sha}] | sort_by(.ref)')
+          target_ref="refs/heads/$TARGET-branch-deploy-lock"
+          [[ $(jq -c --arg ref "$target_ref" 'map(select(.ref != $ref))' <<<"$locks") == "$OTHER_LOCKS" ]]
+          current_lock=$(jq -r --arg ref "$target_ref" '.[] | select(.ref == $ref) | .sha' <<<"$locks")
+          if [[ "$REASON" == deployment_ready ]]; then
+            state=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" --jq '.[0].state')
+            if [[ "$ACCEPTANCE_RESULT" == success ]]; then
+              [[ "$state" == success ]]
+            else
+              [[ "$state" == failure || "$state" == error ]]
+            fi
+            printf 'Deployment `%s` at `%s`: `%s`\n' "$DEPLOYMENT_ID" "$SHA" "$state" >>"$GITHUB_STEP_SUMMARY"
+          else
+            gh api --method GET "repos/$GITHUB_REPOSITORY/deployments" -f environment="$TARGET" -f per_page=100 | jq -e --argjson before "$BEFORE_DEPLOYMENTS" 'all(.[]; .id as $id | $before | index($id))' >/dev/null
+          fi
+          case "$REASON" in
+            deployment_ready|noop_ready)
+              if [[ "$STICKY" == true && "$REASON" == deployment_ready ]]; then
+                [[ -n "$current_lock" ]]
+                gh api --method GET "repos/$GITHUB_REPOSITORY/contents/lock.json" -f ref="$TARGET-branch-deploy-lock" --jq '.content' | base64 --decode | jq -e --arg ref "$EXPECTED_REF" --arg target "$TARGET" --arg link "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER#issuecomment-" '.branch == $ref and .environment == $target and .sticky == true and .global == false and (.link | startswith($link))' >/dev/null
+              else
+                [[ -z "$current_lock" ]]
+              fi
+              ;;
+            unlock_completed) [[ -z "$current_lock" ]] ;;
+            *) [[ "$current_lock" == "$BEFORE_LOCK" ]] ;;
+          esac
+          printf '\nUnrelated deployment locks are unchanged.\n' >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test1.yml
+++ b/.github/workflows/test1.yml
@@ -12,5 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out the stack acceptance commit
+        if: ${{ startsWith(github.head_ref, 'issue-495-stack-') }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Honor the stack acceptance failure marker
+        if: ${{ startsWith(github.head_ref, 'issue-495-stack-') }}
+        run: test ! -e .issue-495/fail-test1
       - name: it will pass
         run: echo "success"

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,8 +14,8 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: grantbirki/branch-deploy@main
+        uses: GrantBirki/branch-deploy@117b39b39e0984d3a0fbaabe9454807f0ce5b9ae
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
-          environment_targets: production,development,staging,super production,mellow staging
+          environment_targets: production,development,staging,super production,mellow staging,issue-495


### PR DESCRIPTION
This pull request adds a temporary, exact-SHA test setup for github/branch-deploy#495. It uses disposable PRs and a marker-controlled CI failure to test stack checks without changing repository rules. The setup will be removed after acceptance testing.
